### PR TITLE
Bump goss version from v0.4.7 to v0.4.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ python3-create-venv: ## Create python venv and install PIP packages
 ##
 ## Goss - release versions
 ##
-GOSS_VERSION_TO_CHECK := 0.4.7
+GOSS_VERSION_TO_CHECK := 0.4.9
 
 .PHONY: goss-check-releases-versions
 goss-check-releases-versions: ## Check the latest goss releases versions

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Snyk Known Vulnerabilities](https://snyk.io//test/github/marcinpraczko/ansible-goss-install/badge.svg?targetFile=requirements.txt)](https://snyk.io//test/github/marcinpraczko/ansible-goss-install?targetFile=requirements.txt) [![Galaxy](https://img.shields.io/badge/galaxy-dockpack.base__goss-blue.svg?style=flat)](https://galaxy.ansible.com/marcinpraczko/goss-install)  
+[![Snyk Known Vulnerabilities](https://snyk.io//test/github/marcinpraczko/ansible-goss-install/badge.svg?targetFile=requirements.txt)](https://snyk.io//test/github/marcinpraczko/ansible-goss-install?targetFile=requirements.txt) [![Galaxy](https://img.shields.io/badge/galaxy-dockpack.base__goss-blue.svg?style=flat)](https://galaxy.ansible.com/marcinpraczko/goss-install)
 
 
 # Ansible-goss-install
 
 - Ansible Role Version: `0.1.13`
-- Goss Version: `0.4.7`
+- Goss Version: `0.4.9`
 
 ## Goss resources
 
@@ -94,5 +94,5 @@ This role can be tested locally with `vagrant`
 For more details please run
 
 ```bash
-make testing-installation    ## This will display more instuctions related with testing locally
+make testing-installation    ## This will display more instructions related with testing locally
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "bento/ubuntu-23.10"
-  config.vm.box_version = "202402.01.0"
+  config.vm.box = "bento/ubuntu-24.04"
+  config.vm.box_version = "202404.26.0"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,10 +6,12 @@ goss_dst_dir: bin
 goss_dst_dir_mode: 0755
 
 # Latest version
-goss_version: v0.4.7
-goss_sha256sum: 1206cc17af6d529baefae79c0cad6383c75f3cc68dc152632d393be827b13d5f
+goss_version: v0.4.9
+goss_sha256sum: 87dd36cfa1b8b50554e6e2ca29168272e26755b19ba5438341f7c66b36decc19
 
 # OLD - Add choices here in some point
+#goss_version: v0.4.7
+#goss_sha256sum: 1206cc17af6d529baefae79c0cad6383c75f3cc68dc152632d393be827b13d5f
 # goss_version: v0.4.6
 # goss_sha256sum: bc818caf99cbab563126297ec568d98911d61d2d7a25f4f37068b7a7916130b5
 # goss_version: v0.4.4

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -152,9 +152,9 @@ deploy-tarball: ## Deploy tarball on Vagrant
 ## Testing - Install and verify goss installation on Vagrant
 ##
 
-.PHONY: test-all-afer-build-and-deploy
-test-all-afer-build-and-deploy: ## Test all installations after build and deploy tarball
-test-all-afer-build-and-deploy: \
+.PHONY: test-all-after-build-and-deploy
+test-all-after-build-and-deploy: ## Test all installations after build and deploy tarball
+test-all-after-build-and-deploy: \
 	build-and-deploy-tarball \
 	test-all
 

--- a/tests/init-install-role/requirements.yml
+++ b/tests/init-install-role/requirements.yml
@@ -1,2 +1,2 @@
 - name: marcinpraczko.goss-install
-  src: file:///vagrant/build/marcinpraczko.goss-install-0.1.11-devel-next.tar.gz
+  src: file:///vagrant/build/marcinpraczko.goss-install-0.1.13-devel-next.tar.gz

--- a/tests/test-goss-as-root.yml
+++ b/tests/test-goss-as-root.yml
@@ -6,11 +6,11 @@ file:
 
     /usr/local/bin/goss-linux-amd64:
         exists: true
-        sha256: 1206cc17af6d529baefae79c0cad6383c75f3cc68dc152632d393be827b13d5f
+        sha256: 87dd36cfa1b8b50554e6e2ca29168272e26755b19ba5438341f7c66b36decc19
 
 command:
     /usr/local/bin/goss --version:
         exit-status: 0
-        stdout: ['v0.4.7']
+        stdout: ['v0.4.9']
         stderr: []
         timeout: 10000 # command should finish within 10 seconds

--- a/tests/test-goss-as-user.yml
+++ b/tests/test-goss-as-user.yml
@@ -6,11 +6,11 @@ file:
 
     /home/vagrant/bin/goss-linux-amd64:
         exists: true
-        sha256: 1206cc17af6d529baefae79c0cad6383c75f3cc68dc152632d393be827b13d5f
+        sha256: 87dd36cfa1b8b50554e6e2ca29168272e26755b19ba5438341f7c66b36decc19
 
 command:
     /home/vagrant/bin/goss --version:
         exit-status: 0
-        stdout: ['v0.4.7']
+        stdout: ['v0.4.9']
         stderr: []
         timeout: 10000 # command should finish within 10 seconds


### PR DESCRIPTION
- Fix minor typos in files (not related with functionality)
- Increase vagrant box for testing (started using bento/ubuntu-24.04)